### PR TITLE
Issue with PHP version check

### DIFF
--- a/check.php
+++ b/check.php
@@ -271,7 +271,7 @@ if (function_exists('apache_get_modules')) {
             echo ">= " . $reqList[$laravelVersion]['php'];
         }
 
-        echo " " . $requirements['php_version'] ? $strOk : $strFail; ?>
+        echo " " . ($requirements['php_version'] ? $strOk : $strFail); ?>
     </p>
 
 


### PR DESCRIPTION
I tested the script on a server which has PHP 5.6 for Laravel version 5.6, and the first requirement for PHP showed "true". I propose to surround the ternary test with brackets.